### PR TITLE
Criar tela de login

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { LockIcon, UserIcon } from "lucide-react";
+import { AutenticarUsuarioRequest } from "../../features/usuario/models/dto.model";
+import { LoginForm } from "../../features/usuario/models/form.model";
+import { authService } from "../../features/usuario/services/auth.service";
+import FyButton from "../../shared/components/fy-button/FyButton";
+import FyInput from "../../shared/components/fy-input/FyInput";
+import { useForm } from "../../shared/hooks/use-form";
+import { dependencies, validateLogin } from "./validation";
+import { useRouter } from "next/navigation";
+
+
+export default function Login() {
+    const router = useRouter();
+
+    const { values, errors, handleChange, isValid } = useForm<LoginForm>({
+        nomeUsuario: '',
+        senha: '',
+    }, validateLogin, dependencies)
+
+    const onSubmit = () => {
+        if (!isValid()) return;
+        const dto: AutenticarUsuarioRequest = values;
+        authService.autenticarUsuario(dto).then(() => {
+            console.log('Usuário logado com sucesso!')
+            router.push('/dashboard')
+        }).catch(err => {
+            console.error('Houve um erro: ', err);
+        })
+    }
+
+    return (
+        <div>
+            <div className="flex flex-col gap-y-4">
+                <div className="flex flex-col gap-y-2">
+                    <h2>Criar conta</h2>
+                    <span>Comece sua jornada musical gratuitamente</span>
+                </div>
+                <div className="flex flex-col gap-y-3">
+                    <FyInput id="nome-usuario-id" name="nome-usuario" label="Nome de usuário"
+                        placeholder="Seu nome de usuário" icon={<UserIcon />}
+                        onChange={(value) => handleChange("nomeUsuario", value)}
+                        error={errors.nomeUsuario}
+                    ></FyInput>
+                    <FyInput id="senha-id" name="senha" label="Senha"
+                        placeholder="Sua senha" icon={<LockIcon />}
+                        onChange={(value) => handleChange("senha", value)}
+                        error={errors.senha} type="password"
+                    ></FyInput>
+                    <FyButton onClick={onSubmit}>
+                        Entrar
+                    </FyButton>
+                </div>
+                <div>
+                    {/* links */}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -34,7 +34,7 @@ export default function Login() {
         <div>
             <div className="flex flex-col gap-y-4">
                 <div className="flex flex-col gap-y-2">
-                    <h2>Criar conta</h2>
+                    <h2>Login</h2>
                     <span>Comece sua jornada musical gratuitamente</span>
                 </div>
                 <div className="flex flex-col gap-y-3">

--- a/src/app/(auth)/login/validation.tsx
+++ b/src/app/(auth)/login/validation.tsx
@@ -1,0 +1,21 @@
+import { LoginForm } from "../../features/usuario/models/form.model";
+
+import { isBlank, isPassword } from "../../shared/utils/validation";
+
+export const dependencies: Partial<Record<keyof LoginForm, (keyof LoginForm)[]>> = {};
+
+export const validateLogin = (
+    field: keyof LoginForm,
+    values: LoginForm
+): string | null => {
+    switch (field) {
+        case "nomeUsuario":
+            if (isBlank(values.nomeUsuario)) return "Nome de usuário obrigatório";
+            return null;
+        case "senha":
+            if (!isPassword(values.senha)) return "Senha inválida";
+            return null;
+        default:
+            return null;
+    }
+};

--- a/src/app/(home)/dashboard/page.tsx
+++ b/src/app/(home)/dashboard/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { authService } from "../../features/usuario/services/auth.service"
+
+export default function Dashboard() {
+    const router = useRouter();
+
+    const logout = async () => {
+        await authService.logout();
+        router.push('/login');
+    }
+
+    return (
+        <div>
+            <h1 className="text-2xl">Dashboard temporário super legal!</h1>
+            <button className="bg-red-600 text-white cursor-pointer p-2 rounded-2xl" onClick={logout}>Sair</button>
+        </div>
+    )
+}

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from "react";
+
+export default function HomeLayout({ children }: { children: ReactNode }) {
+    return (
+        <>
+            {children}
+        </>
+    );
+}

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import {
+  AutenticarUsuarioRequest,
+  TokenResponse,
+} from "../../../features/usuario/models/dto.model";
+import { isBlank, isPassword } from "../../../shared/utils/validation";
+import httpServer from "../../../infrastructure/http/http-server";
+import { cookies } from "next/headers";
+
+export async function POST(request: Request): Promise<Response> {
+  const body: AutenticarUsuarioRequest = await request.json();
+  if (isBlank(body.nomeUsuario))
+    return NextResponse.json({ error: "Nome inválido!" }, { status: 400 });
+
+  if (!isPassword(body.senha))
+    return NextResponse.json({ error: "Senha inválida!" }, { status: 400 });
+
+  const response = await httpServer.post<TokenResponse>("/usuarios/auth/login", body);
+
+  const cookieStore = await cookies();
+  
+  cookieStore.set("refresh_token", response.data.refreshToken, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "strict",
+    path: "/",
+  });
+
+  cookieStore.set("access_token", response.data.accessToken, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "strict",
+    path: "/",
+  });
+
+  return NextResponse.json(response.data);
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,24 @@
+import httpServer from "@/src/app/infrastructure/http/http-server";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+export async function POST(): Promise<Response> {
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get("refresh_token")?.value;
+
+  if (refreshToken === undefined || refreshToken === null)
+    return NextResponse.json(
+      { error: "Usuário não está autenticado!" },
+      { status: 401 },
+    );
+
+  await httpServer.post("/usuarios/auth/logout", { refreshToken });
+
+  cookieStore.delete("refresh_token");
+  cookieStore.delete("access_token");
+
+  return NextResponse.json({
+    status: true,
+    message: "Usuário deslogado com sucesso!",
+  });
+}

--- a/src/app/api/usuarios/route.ts
+++ b/src/app/api/usuarios/route.ts
@@ -38,7 +38,7 @@ export async function POST(request: Request): Promise<Response> {
     );
 
   const response = await httpServer.post<NovoRecursoResponse>(
-    "/usuarios",
+    "usuarios/auth/register",
     body,
   );
 

--- a/src/app/features/usuario/models/dto.model.ts
+++ b/src/app/features/usuario/models/dto.model.ts
@@ -5,3 +5,13 @@ export interface CriarUsuarioRequest {
     senhaNovamente: string;
     dataNascimento: Date;
 }
+
+export interface AutenticarUsuarioRequest {
+    nomeUsuario: string;
+    senha: string;
+}
+
+export interface TokenResponse {
+    accessToken: string;
+    refreshToken: string;
+}

--- a/src/app/features/usuario/models/form.model.ts
+++ b/src/app/features/usuario/models/form.model.ts
@@ -6,3 +6,8 @@ export interface RegisterForm {
     senhaNovamente: string;
     dataNascimento: string;
 }
+
+export interface LoginForm {
+    nomeUsuario: string;
+    senha: string;
+}

--- a/src/app/features/usuario/services/auth.service.ts
+++ b/src/app/features/usuario/services/auth.service.ts
@@ -1,0 +1,14 @@
+import httpClient from "@/src/app/infrastructure/http/http-client";
+import { AutenticarUsuarioRequest, TokenResponse } from "../models/dto.model";
+
+export class AuthService {
+  async autenticarUsuario(request: AutenticarUsuarioRequest) {
+    await httpClient.post<TokenResponse>("auth/login", request);
+  }
+
+  async logout() {
+    await httpClient.post("auth/logout");
+  }
+}
+
+export const authService = new AuthService();

--- a/src/app/features/usuario/services/usuario.service.ts
+++ b/src/app/features/usuario/services/usuario.service.ts
@@ -5,7 +5,6 @@ import { NovoRecursoResponse } from "@/src/app/shared/models/http.model";
 export class UsuarioService {
     async cadastrarUsuario(request: CriarUsuarioRequest) {
         const response = await httpClient.post<NovoRecursoResponse>('usuarios', request);
-        console.log(response);
     }
 }
 

--- a/src/app/infrastructure/http/http-client.ts
+++ b/src/app/infrastructure/http/http-client.ts
@@ -1,19 +1,15 @@
 import axios from "axios";
 
 const httpClient = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000/api",
+  baseURL:
+    process.env.NEXT_PUBLIC_API_URL
+    || "http://localhost:3000/api",
+
   headers: {
     "Content-Type": "application/json",
   },
+
+  withCredentials: true,
 });
-
-httpClient.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 401) console.log("Não autorizado");
-
-    return Promise.reject(error);
-  },
-);
 
 export default httpClient;

--- a/src/app/infrastructure/http/http-server.ts
+++ b/src/app/infrastructure/http/http-server.ts
@@ -1,5 +1,8 @@
 import axios from "axios";
 
+/**
+ * @deprecated Use apenas para rotas públicas
+ */
 const httpServer = axios.create({
   baseURL: process.env.BACKEND_API_URL || "http://localhost:8080",
   headers: {

--- a/src/app/infrastructure/http/server-http.ts
+++ b/src/app/infrastructure/http/server-http.ts
@@ -1,0 +1,76 @@
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
+
+import { cookies } from "next/headers";
+
+const API_URL = process.env.BACKEND_API_URL || "http://localhost:8080";
+
+export async function serverApiRequest<T>(
+  config: AxiosRequestConfig,
+): Promise<AxiosResponse<T>> {
+  const cookieStore = await cookies();
+
+  const accessToken = cookieStore.get("access_token")?.value;
+
+  try {
+    return await axios({
+      ...config,
+
+      baseURL: API_URL,
+
+      headers: {
+        ...config.headers,
+
+        ...(accessToken && {
+          Authorization: `Bearer ${accessToken}`,
+        }),
+      },
+    });
+  } catch (error) {
+    const axiosError = error as AxiosError;
+
+    if (axiosError.response?.status !== 401) {
+      throw error;
+    }
+
+    const refreshToken = cookieStore.get("refresh_token")?.value;
+
+    if (!refreshToken) {
+      throw error;
+    }
+
+    try {
+      const refreshResponse = await axios.post(
+        `${API_URL}/usuarios/auth/refresh`,
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${refreshToken}`,
+          },
+        },
+      );
+
+      const newAccessToken = refreshResponse.data.accessToken;
+
+      cookieStore.set("access_token", newAccessToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "strict",
+        path: "/",
+      });
+
+      return axios({
+        ...config,
+        baseURL: API_URL,
+        headers: {
+          ...config.headers,
+          Authorization: `Bearer ${newAccessToken}`,
+        },
+      });
+    } catch {
+      cookieStore.delete("access_token");
+      cookieStore.delete("refresh_token");
+
+      throw error;
+    }
+  }
+}

--- a/src/app/shared/utils/auth-client.ts
+++ b/src/app/shared/utils/auth-client.ts
@@ -1,0 +1,14 @@
+export function getAccessToken() {
+  return document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("access_token="))
+    ?.split("=")[1];
+}
+
+export function setAccessToken(token: string) {
+  document.cookie = `access_token=${token}; path=/`;
+}
+
+export function removeAccessToken() {
+  document.cookie = "access_token=; Max-Age=0; path=/";
+}

--- a/src/app/shared/utils/auth-server.ts
+++ b/src/app/shared/utils/auth-server.ts
@@ -1,0 +1,7 @@
+import { cookies } from "next/headers";
+
+export async function getAccessTokenServer() {
+  const cookieStore = await cookies();
+
+  return cookieStore.get("access_token")?.value;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const publicOnlyRoutes = ["/login", "/register"];
+
+export function proxy(request: NextRequest) {
+  const accessToken = request.cookies.get("access_token");
+
+  const pathname = request.nextUrl.pathname;
+
+  const isPublicOnlyRoute = publicOnlyRoutes.some((route) =>
+    pathname.startsWith(route),
+  );
+
+  if (!accessToken && !isPublicOnlyRoute) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  if (accessToken && isPublicOnlyRoute) {
+    return NextResponse.redirect(new URL("/dashboard", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
O presente pr tem como contribuição criar a tela de login, adicionando funcionalidade integrada com a API de login e logout. Além disso, cria um proxy (middleware) para validar se o usuário está logado e cria um helper para realizar requisições para rotas protegidas da API.

Requisições para rotas públicas da API devem usar o http-server, client http antigo para API que agora está depreciado.